### PR TITLE
Introduce recursive record types

### DIFF
--- a/src/GraphQL/Type.purs
+++ b/src/GraphQL/Type.purs
@@ -23,6 +23,7 @@ module GraphQL.Type
        , enumType
        , enumValue
        , objectType
+       , objectTypeRec
        , field
        , field'
        , argument
@@ -223,6 +224,18 @@ objectType :: ∀ a ctx fields. Homogeneous fields (ObjectTypeField ctx a)
 objectType name description =
   runFn3 _objectType name $ toNullable description
 
+-- | Create a new recursive object type with:
+-- | - `name` is the name of the object in the schema
+-- | - `description` is the description of the type
+-- | - `fields` is a function returning a record of field definitions
+objectTypeRec :: ∀ a ctx fields. Homogeneous fields (ObjectTypeField ctx a)
+  => String
+  -> Maybe String
+  -> (Unit -> Record fields)
+  -> ObjectType ctx (Maybe a)
+objectTypeRec name description =
+  runFn3 _objectType name $ toNullable description
+
 -- | Create a simple field without arguments using
 -- | - `type` the type of the field
 -- | - `description` the description of the field
@@ -364,7 +377,7 @@ foreign import _enumType :: ∀ a.
   Fn3 String (Nullable String) (Array (EnumValue a)) (EnumType (Maybe a))
 
 foreign import _objectType :: ∀ a ctx fields.
-  Fn3 String (Nullable String) (Record fields) (ObjectType ctx a)
+  Fn3 String (Nullable String) fields (ObjectType ctx a)
 
 boundField :: ∀ t a b decl args ctx.
   Fn4


### PR DESCRIPTION
This enables recursive record types. Values cannot be referenced from each other in PureScript, the compiler will issue an error. It is possible to wrap these values in a function and then reference them recursively. The function `objectTypeRec` does the trick.

Fixes: #5 